### PR TITLE
Add endpoint provider parameter to getTeslaClient.

### DIFF
--- a/lib/tool.dart
+++ b/lib/tool.dart
@@ -35,7 +35,10 @@ String _getEnvKey(List<String> possible) {
       "Expected environment variable '${possible.first}' to be present.");
 }
 
-TeslaClient getTeslaClient({String teslaUsername, String teslaPassword}) {
+TeslaClient getTeslaClient(
+    {String teslaUsername,
+    String teslaPassword,
+    TeslaApiEndpoints endpoints}) {
   var email = teslaUsername ?? _getEnvKey(_emailEnvVars).trim();
   var password = teslaPassword ?? _getEnvKey(_passwordEnvVars);
 
@@ -48,5 +51,5 @@ TeslaClient getTeslaClient({String teslaUsername, String teslaPassword}) {
     password = password.substring(0, password.length - 1);
   }
 
-  return new TeslaClient(email, password);
+  return new TeslaClient(email, password, endpoints: endpoints);
 }


### PR DESCRIPTION
Working on an Aqueduct application that will stub out the Tesla API, I want to add this as an optional parameter so that we can pass in a different Endpoint provider class implementation. We can use this to build a testing framework in the future.