### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/impl/io.dart
+++ b/lib/src/impl/io.dart
@@ -51,7 +51,8 @@ class TeslaClientImpl extends TeslaHttpClient {
       request.write(const JsonEncoder().convert(body));
     }
     var response = await request.close();
-    var content = await response.transform(const Utf8Decoder()).join();
+    var content =
+        await response.cast<List<int>>().transform(const Utf8Decoder()).join();
     if (response.statusCode != 200) {
       throw new Exception(
           "Failed to perform action. (Status Code: ${response.statusCode})\n${content}");

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tesla
 description: "Control and monitor Tesla Products"
-version: 0.1.1
+version: 0.1.1+1
 homepage: "https://github.com/SpinlockLabs/tesla.dart"
 authors:
 - "Kenneth Endfinger <kaendfinger@gmail.com>"

--- a/tool/extract_option_codes.dart
+++ b/tool/extract_option_codes.dart
@@ -29,6 +29,7 @@ class VehicleOptionCode {
   var codes = <String>[];
 
   await for (var line in response
+      .cast<List<int>>()
       .transform(const Utf8Decoder())
       .transform(const LineSplitter())) {
     if (!line.startsWith("| ")) {


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900